### PR TITLE
Fix finetune ui setting error

### DIFF
--- a/scripts/tabs/training/fine_tune.py
+++ b/scripts/tabs/training/fine_tune.py
@@ -19,7 +19,7 @@ def create_ui():
     sd_saving_arguments = argparse.ArgumentParser()
     optimizer_arguments = argparse.ArgumentParser()
     train_util.add_sd_models_arguments(sd_models_arguments)
-    train_util.add_dataset_arguments(dataset_arguments, True, False, True)
+    train_util.add_dataset_arguments(dataset_arguments, False, True, True)
     train_util.add_training_arguments(training_arguments, True)
     train_util.add_sd_saving_arguments(sd_saving_arguments)
     train_util.add_optimizer_arguments(optimizer_arguments)

--- a/scripts/tabs/training/fine_tune.py
+++ b/scripts/tabs/training/fine_tune.py
@@ -20,7 +20,7 @@ def create_ui():
     optimizer_arguments = argparse.ArgumentParser()
     train_util.add_sd_models_arguments(sd_models_arguments)
     train_util.add_dataset_arguments(dataset_arguments, False, True, True)
-    train_util.add_training_arguments(training_arguments, True)
+    train_util.add_training_arguments(training_arguments, False)
     train_util.add_sd_saving_arguments(sd_saving_arguments)
     train_util.add_optimizer_arguments(optimizer_arguments)
     sd_models_options = {}


### PR DESCRIPTION
For Finetune Setting,support_dreambooth should be false,support_caption should be true,and support_caption_dropout is optional.